### PR TITLE
use components loaded event

### DIFF
--- a/src/image-remote-transpiled-chromeos.html
+++ b/src/image-remote-transpiled-chromeos.html
@@ -74,9 +74,8 @@
       RisePlayerConfiguration.configure({
         playerType: "beta"
       }, {
-        player: "electron",
-        connectionType: "websocket",
-        detail: { serverUrl: "http://localhost:8080" }
+        player: "chromeos",
+        connectionType: "window"
       });
     </script>
   </head>

--- a/src/image-remote-transpiled-chromeos.html
+++ b/src/image-remote-transpiled-chromeos.html
@@ -14,11 +14,11 @@
     <script type="module">
       import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
     </script>
-    <script src="https://widgets.risevision.com/staging/common/2018.10.05.10.00/rise-player-configuration.js"></script>
-    <script src="https://widgets.risevision.com/staging/common/2018.10.05.10.00/rise-local-messaging.js"></script>
-    <script src="https://widgets.risevision.com/staging/common/2018.10.05.10.00/rise-helpers.js"></script>
-    <script src="https://widgets.risevision.com/staging/common/2018.10.05.10.00/rise-local-storage.js"></script>
-    <script src="https://widgets.risevision.com/staging/common/2018.10.05.10.00/rise-component-loader.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-player-configuration.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-local-messaging.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-helpers.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
     <script>
       if (document.domain.indexOf("localhost") === -1) {
         try {
@@ -39,7 +39,7 @@
         console.log( "configuring components" );
 
         // this manual fetch and script injection won't be necessary after next card
-        fetch('https://widgets.risevision.com/staging/components/rise-data-image/2018.10.03.16.20/rise-data-image.js')
+        fetch('https://widgets.risevision.com/beta/components/rise-data-image/rise-data-image.js')
         .then(response => response.text())
         .then(code => {
           let script = document.createElement('script');

--- a/src/image-remote-transpiled.html
+++ b/src/image-remote-transpiled.html
@@ -14,11 +14,11 @@
     <script type="module">
       import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
     </script>
-    <script src="https://widgets.risevision.com/staging/common/2018.10.05.10.00/rise-player-configuration.js"></script>
-    <script src="https://widgets.risevision.com/staging/common/2018.10.05.10.00/rise-local-messaging.js"></script>
-    <script src="https://widgets.risevision.com/staging/common/2018.10.05.10.00/rise-helpers.js"></script>
-    <script src="https://widgets.risevision.com/staging/common/2018.10.05.10.00/rise-local-storage.js"></script>
-    <script src="https://widgets.risevision.com/staging/common/2018.10.05.10.00/rise-component-loader.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-player-configuration.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-local-messaging.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-helpers.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
     <script>
       if (document.domain.indexOf("localhost") === -1) {
         try {
@@ -39,7 +39,7 @@
         console.log( "configuring components" );
 
         // this manual fetch and script injection won't be necessary after next card
-        fetch('https://widgets.risevision.com/staging/components/rise-data-image/2018.10.03.16.20/rise-data-image.js')
+        fetch('https://widgets.risevision.com/beta/components/rise-data-image/rise-data-image.js')
         .then(response => response.text())
         .then(code => {
           let script = document.createElement('script');


### PR DESCRIPTION
Pages for ChromeOS and Electron players that helped me test manually the fetch code.

These pages now leverage the rise-components-loaded so manual configuration can be done after components have loaded.

@sheadarlison  New URLs for testing these on displays:

Electron Player:
https://widgets.risevision.com/staging/pages/2018.10.05.13.01/dist/src/image-remote-transpiled.html

ChromeOS Player:
http://widgets.risevision.com/staging/pages/2018.10.05.13.01/chromeos/src/image-remote-transpiled-chromeos.html

( note that ChromeOS page needs to be loaded using HTTP, because viewer is loaded using HTTP; this will change once viewer goes away )
