### PR TITLE
load only rise-data-image on image-remote-transpiled pages

### DIFF
--- a/src/image-remote-transpiled-chromeos.html
+++ b/src/image-remote-transpiled-chromeos.html
@@ -29,6 +29,14 @@
           console.log("document.domain can't be set", err);
         }
       }
+
+      // only load rise-data-image
+      RisePlayerConfiguration.ComponentLoader.components = [
+        {
+          name: "rise-data-image",
+          url: "https://widgets.risevision.com/beta/components/rise-data-image/rise-data-image.js"
+        }
+      ];
     </script>
     <script>
       function configureComponents() {

--- a/src/image-remote-transpiled.html
+++ b/src/image-remote-transpiled.html
@@ -29,6 +29,14 @@
           console.log("document.domain can't be set", err);
         }
       }
+
+      // only load rise-data-image
+      RisePlayerConfiguration.ComponentLoader.components = [
+        {
+          name: "rise-data-image",
+          url: "https://widgets.risevision.com/beta/components/rise-data-image/rise-data-image.js"
+        }
+      ];
     </script>
     <script>
       function configureComponents() {


### PR DESCRIPTION
The sample pages with rise-data-image are failing because loader invokes the rise-data-financial code and it does not find the firebase scripts.

Instead of including them here ( they are not needed ), I did an override to only load the image component.

All of these won't be necessary later with the latest staggered release implementation.
