### PR TITLE
change electron reference to ChromeOS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ in the meantime.
 Alternatively, all build/es5 may be uploaded to GCS, with public permissions
 and no caching; and the schedule may point to the published file.
 
-## Build & run instructions - Player Electron
+## Build & run instructions - ChromeOS Player
 
 Currently, the image-remote-transpiled.html is fixed for Player Electron.
 To build the test page for ChromeOS player one should use the provided file


### PR DESCRIPTION
The title of this section references incorrectly player-electron instead of ChromeOS player, may be a minor source of confusion so it's better to correct it.